### PR TITLE
Add RSS feed, remove sources.xml, update parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Documentation is organized using the Diataxis model:
 |------|------------|
 | Tutorials | [Deploy `server-streampack`](docs/tutorials/deploy-server-streampack.md), [run the infobot on IRC](docs/tutorials/run-infobot-on-irc.md), [write your first operation](docs/tutorials/write-your-first-operation.md) |
 | How-to | [Configure deployment environment](docs/how-to/deploy/configure-env.md), [build and publish the container](docs/how-to/deploy/build-and-publish-container.md) |
-| Reference | [Modules](docs/reference/modules.md), [environment variables](docs/reference/environment-variables.md), [infobot commands](docs/reference/infobot-commands.md), [OpenAPI](docs/openapi.json) |
+| Reference | [Modules](docs/reference/modules.md), [environment variables](docs/reference/environment-variables.md), [infobot commands](docs/reference/infobot-commands.md), [command parser](docs/reference/command-parser.md), [OpenAPI](docs/openapi.json) |
 | Explanation | [What is Streampack?](docs/explanation/what-is-streampack.md), [platform vs bundled server](docs/explanation/platform-vs-server-streampack.md) |
 
 ## License

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>coverage-report</artifactId>

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,4 @@ For the bundled bot command surface, use:
 
 - [Use the Infobot](how-to/infobot/use-the-infobot.md) for the public user guide
 - [Admin Text Operations](reference/admin-text-operations.md) for repository-facing operator commands
+- [Command Parser](reference/command-parser.md) for parser internals and grammar/help rendering

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3858,6 +3858,28 @@
         "tags" : [ "Posts" ]
       }
     },
+    "/posts/{id}/access" : {
+      "post" : {
+        "operationId" : "recordPostAccess",
+        "parameters" : [ {
+          "description" : "Post UUIDv7",
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "default" : "##default",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "202" : {
+            "description" : "Access tracking accepted"
+          }
+        },
+        "summary" : "Record a UI-driven access of a blog post",
+        "tags" : [ "Posts" ]
+      }
+    },
     "/posts/{year}/{month}/{slug}" : {
       "get" : {
         "description" : "Returns full post detail including rendered HTML, tags, categories, and comment count. Draft posts are only visible to their author and admins.",
@@ -4232,44 +4254,6 @@
           }
         },
         "summary" : "Record a UI-driven access of a stored RSS item",
-        "tags" : [ "RSS Aggregator" ]
-      }
-    },
-    "/rss/sources.xml" : {
-      "get" : {
-        "operationId" : "aggregatedFeed",
-        "parameters" : [ {
-          "in" : "query",
-          "name" : "feed",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "in" : "query",
-          "name" : "title",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/rss+xml" : {
-                "schema" : {
-                  "additionalProperties" : {
-                    "default" : "##default"
-                  },
-                  "default" : "##default",
-                  "type" : "string"
-                }
-              }
-            },
-            "description" : "Aggregated RSS feed"
-          }
-        },
-        "summary" : "Generate an aggregated RSS feed of stored items",
         "tags" : [ "RSS Aggregator" ]
       }
     },

--- a/docs/reference/command-parser.md
+++ b/docs/reference/command-parser.md
@@ -1,0 +1,191 @@
+# Command Parser
+
+The Streampack command parser lives in `lib-core` under `dev.streampack.core.parser`.
+
+It is a small grammar-and-matching layer for text commands. It is not yet the universal command
+entry point for every operation in the codebase, but it is the preferred foundation for new
+text-command parsing work.
+
+## Design
+
+The parser has four parts:
+
+- `CommandLexer`
+  Tokenizes raw input, strips an optional leading `!`, preserves quoted segments, and marks whether
+  the input was explicitly triggered.
+- `CommandPattern`
+  Declares fixed leading literals plus typed positional arguments.
+- `CommandArgType`
+  Validates and converts one token into a typed value.
+- `CommandPatternMatcher`
+  Tries patterns in order, returns the first full match, and otherwise returns the strongest
+  failure reason among literal-prefix matches.
+
+The parser is intentionally conservative:
+
+- no hidden backtracking DSL
+- no magical optional-argument inference
+- one-token-at-a-time argument validation
+- plain return types that are easy to inspect in tests
+
+## Example
+
+This pattern set models a tiny boolean command tree:
+
+```kotlin
+val booleanArgType = ChoiceArgType(setOf("true", "false"))
+
+fun booleanArg(name: String, helpText: String? = null) =
+    CommandArgSpec(name, booleanArgType, helpText)
+
+val matcher =
+    CommandPatternMatcher(
+        listOf(
+            CommandPattern(
+                name = "boolean_xor",
+                literals = listOf("boolean", "xor"),
+                args =
+                    listOf(
+                        booleanArg("left", "Left boolean operand"),
+                        booleanArg("right", "Right boolean operand"),
+                    ),
+                summary = "Exclusive-or over two boolean inputs",
+            ),
+            CommandPattern(
+                name = "boolean_and",
+                literals = listOf("boolean", "and"),
+                args =
+                    listOf(
+                        booleanArg("left", "Left boolean operand"),
+                        booleanArg("right", "Right boolean operand"),
+                    ),
+                summary = "Logical and over two boolean inputs",
+            ),
+            CommandPattern(
+                name = "boolean_or",
+                literals = listOf("boolean", "or"),
+                args =
+                    listOf(
+                        booleanArg("left", "Left boolean operand"),
+                        booleanArg("right", "Right boolean operand"),
+                    ),
+                summary = "Logical or over two boolean inputs",
+            ),
+            CommandPattern(
+                name = "boolean_not",
+                literals = listOf("boolean", "not"),
+                args = listOf(booleanArg("value", "Boolean input to negate")),
+                summary = "Logical not over one boolean input",
+            ),
+            CommandPattern(
+                name = "boolean_help",
+                literals = listOf("boolean", "help"),
+                summary = "Show boolean command help",
+            ),
+        )
+    )
+```
+
+Matching:
+
+```kotlin
+val result = matcher.match("boolean xor true false")
+```
+
+Produces:
+
+```kotlin
+CommandMatchResult.Match(
+    patternName = "boolean_xor",
+    captures = mapOf("left" to "true", "right" to "false"),
+    triggered = false,
+    tokens = listOf("boolean", "xor", "true", "false"),
+)
+```
+
+## Grammar Rendering
+
+`CommandPatternMatcher` can render its own grammar from the declared patterns:
+
+```kotlin
+matcher.describeGrammar()
+```
+
+Returns:
+
+```text
+boolean xor <left:one-of(false|true)> <right:one-of(false|true)>
+boolean and <left:one-of(false|true)> <right:one-of(false|true)>
+boolean or <left:one-of(false|true)> <right:one-of(false|true)>
+boolean not <value:one-of(false|true)>
+boolean help
+```
+
+And richer help output:
+
+```kotlin
+matcher.describeHelp()
+```
+
+Returns:
+
+```text
+boolean xor <left:one-of(false|true)> <right:one-of(false|true)> -- Exclusive-or over two boolean inputs
+  <left:one-of(false|true)>: Left boolean operand
+  <right:one-of(false|true)>: Right boolean operand
+boolean and <left:one-of(false|true)> <right:one-of(false|true)> -- Logical and over two boolean inputs
+  <left:one-of(false|true)>: Left boolean operand
+  <right:one-of(false|true)>: Right boolean operand
+boolean or <left:one-of(false|true)> <right:one-of(false|true)> -- Logical or over two boolean inputs
+  <left:one-of(false|true)>: Left boolean operand
+  <right:one-of(false|true)>: Right boolean operand
+boolean not <value:one-of(false|true)> -- Logical not over one boolean input
+  <value:one-of(false|true)>: Boolean input to negate
+boolean help -- Show boolean command help
+```
+
+This is the current self-documentation surface for issue `#18`: plain list-of-strings output that a
+caller can publish in chat, logs, or a higher-level help system.
+
+## Failure Semantics
+
+If no literal prefix matches, `match(...)` returns `null`.
+
+If a literal prefix matches but the full command fails, the matcher returns the strongest failure:
+
+1. `InvalidArgument`
+2. `MissingArguments`
+3. `TooManyArguments`
+
+This means callers can distinguish:
+
+- "this is not my command"
+- "this command is mine, but the user used it incorrectly"
+
+without needing a second parser pass.
+
+## Built-in Argument Types
+
+- `StringArgType`
+- `UsernameArgType`
+- `HttpUrlArgType`
+- `PositiveIntArgType`
+- `IntRangeArgType`
+- `ChoiceArgType`
+
+Each argument type exposes a `syntaxName` used in grammar/help rendering.
+
+## Guidance
+
+- Prefer one pattern per command form instead of trying to encode too much optionality into one
+  shape.
+- Use `ChoiceArgType` for small enumerations that should appear clearly in help output.
+- Use explicit summaries and argument help text when the command has a non-trivial meaning.
+- Keep grammar rendering close to the parser definitions instead of hand-maintaining parallel help
+  text when possible.
+
+## Current Scope
+
+The parser is adopted by some newer text operations, but not every command in Streampack uses it
+yet. The current goal is to make the parser itself unambiguous and self-describing first, then
+incrementally migrate command handlers toward it over time.

--- a/lib-ai/pom.xml
+++ b/lib-ai/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-ai</artifactId>

--- a/lib-blog/pom.xml
+++ b/lib-blog/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-blog</artifactId>

--- a/lib-blog/src/main/kotlin/dev/streampack/blog/entity/Post.kt
+++ b/lib-blog/src/main/kotlin/dev/streampack/blog/entity/Post.kt
@@ -32,6 +32,8 @@ data class Post(
     val status: PostStatus = PostStatus.DRAFT,
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "author_id") val author: User? = null,
     val publishedAt: Instant? = null,
+    @Column(nullable = false) val accessCount: Long = 0,
+    @Column val lastAccessedAt: Instant? = null,
     @Column(nullable = false) val createdAt: Instant = Instant.now(),
     @Column(nullable = false) val updatedAt: Instant = Instant.now(),
     @Column(nullable = false) val deleted: Boolean = false,

--- a/lib-blog/src/main/kotlin/dev/streampack/blog/model/RecordPostAccessRequest.kt
+++ b/lib-blog/src/main/kotlin/dev/streampack/blog/model/RecordPostAccessRequest.kt
@@ -1,0 +1,7 @@
+/* Joseph B. Ottinger (C)2026 */
+package dev.streampack.blog.model
+
+import java.util.UUID
+
+/** Internal request to record a UI-driven access of a blog post. */
+data class RecordPostAccessRequest(val id: UUID)

--- a/lib-blog/src/main/kotlin/dev/streampack/blog/operation/RecordPostAccessOperation.kt
+++ b/lib-blog/src/main/kotlin/dev/streampack/blog/operation/RecordPostAccessOperation.kt
@@ -1,0 +1,28 @@
+/* Joseph B. Ottinger (C)2026 */
+package dev.streampack.blog.operation
+
+import dev.streampack.blog.model.RecordPostAccessRequest
+import dev.streampack.blog.repository.PostRepository
+import dev.streampack.core.model.Consumed
+import dev.streampack.core.model.OperationOutcome
+import dev.streampack.core.service.TypedOperation
+import java.time.Instant
+import org.springframework.messaging.Message
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/** Internal bookkeeping operation for UI-driven blog post access tracking. */
+@Component
+class RecordPostAccessOperation(private val postRepository: PostRepository) :
+    TypedOperation<RecordPostAccessRequest>(RecordPostAccessRequest::class) {
+
+    @Transactional
+    override fun handle(payload: RecordPostAccessRequest, message: Message<*>): OperationOutcome {
+        val post =
+            postRepository.findById(payload.id).orElse(null) ?: return Consumed("post missing")
+        postRepository.save(
+            post.copy(accessCount = post.accessCount + 1, lastAccessedAt = Instant.now())
+        )
+        return Consumed("recorded blog post access ${payload.id}")
+    }
+}

--- a/lib-blog/src/main/resources/db/migration/V35__add_post_access_tracking.sql
+++ b/lib-blog/src/main/resources/db/migration/V35__add_post_access_tracking.sql
@@ -1,0 +1,5 @@
+ALTER TABLE posts
+    ADD COLUMN access_count BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN last_accessed_at TIMESTAMPTZ NULL;
+
+CREATE INDEX idx_posts_access_count ON posts(access_count DESC, created_at DESC);

--- a/lib-blog/src/test/kotlin/dev/streampack/blog/operation/RecordPostAccessOperationTests.kt
+++ b/lib-blog/src/test/kotlin/dev/streampack/blog/operation/RecordPostAccessOperationTests.kt
@@ -1,0 +1,57 @@
+/* Joseph B. Ottinger (C)2026 */
+package dev.streampack.blog.operation
+
+import dev.streampack.blog.entity.Post
+import dev.streampack.blog.model.PostStatus
+import dev.streampack.blog.model.RecordPostAccessRequest
+import dev.streampack.blog.repository.PostRepository
+import dev.streampack.core.integration.EventGateway
+import dev.streampack.core.model.OperationResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class RecordPostAccessOperationTests {
+
+    @Autowired lateinit var eventGateway: EventGateway
+    @Autowired lateinit var postRepository: PostRepository
+
+    private lateinit var postId: java.util.UUID
+
+    @BeforeEach
+    fun setUp() {
+        postId =
+            postRepository
+                .save(
+                    Post(
+                        title = "Tracked Post",
+                        markdownSource = "Tracked markdown.",
+                        renderedHtml = "<p>Tracked markdown.</p>",
+                        excerpt = "Tracked markdown.",
+                        status = PostStatus.APPROVED,
+                    )
+                )
+                .id
+    }
+
+    @Test
+    fun `record post access request increments persisted usage`() {
+        val result =
+            eventGateway.process(
+                MessageBuilder.withPayload(RecordPostAccessRequest(postId)).build()
+            )
+
+        assertEquals(OperationResult.NotHandled, result)
+        postRepository.flush()
+        val refreshed = postRepository.findById(postId).orElseThrow()
+        assertEquals(1, refreshed.accessCount)
+        assertNotNull(refreshed.lastAccessedAt)
+    }
+}

--- a/lib-core/README.md
+++ b/lib-core/README.md
@@ -12,6 +12,22 @@
 | `OperationService` | Executes registered operations in priority order and publishes terminal results. |
 | `OperationConfigService` | Stores global and per-provenance operation configuration. |
 
+## Command Parser
+
+`lib-core` also contains the shared text-command parser under `dev.streampack.core.parser`.
+
+Core parser types:
+
+| Type | Purpose |
+|------|---------|
+| `CommandLexer` | Tokenizes raw text, strips an optional leading `!`, and preserves quoted tokens. |
+| `CommandPattern` | Declares fixed literals plus typed positional arguments. |
+| `CommandArgType` | Validates and converts one token into a typed value. |
+| `CommandPatternMatcher` | Matches input against patterns and can render grammar/help lines from those patterns. |
+
+The parser is intended to become the preferred foundation for text-command parsing, but not every
+operation has migrated to it yet.
+
 ## Operation Outcomes
 
 - `OperationResult.Success`: definitive answer that is published to egress.
@@ -43,6 +59,9 @@ Protocol-specific identity resolution goes through `ServiceBindingRepository` an
 Use `Consumed` for maintenance work such as queueing, buffering, bookkeeping, or deferred
 background processing that should not generate user-visible output. Use `Declined` only when
 another operation should still get a chance to handle the same message.
+
+For parser details and the new grammar/help rendering surface, see
+[docs/reference/command-parser.md](/Users/joeo/work/streampack-dev/streampack/docs/reference/command-parser.md).
 
 ## Example Flows
 

--- a/lib-core/pom.xml
+++ b/lib-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-core</artifactId>

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/ChoiceArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/ChoiceArgType.kt
@@ -16,6 +16,7 @@ data class ChoiceArgType(
         if (caseInsensitive) options.associateBy { it.lowercase() } else emptyMap()
 
     val validOptions: List<String> = options.toList().sorted()
+    override val syntaxName: String = "one-of(${validOptions.joinToString("|")})"
 
     override fun parse(token: String): String? {
         return if (caseInsensitive) {

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandArgSpec.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandArgSpec.kt
@@ -4,6 +4,13 @@ package dev.streampack.core.parser
 /**
  * Named argument slot in a [CommandPattern].
  *
- * `name` is used as the capture key in [CommandMatchResult.Match.captures].
+ * `name` is used as the capture key in [CommandMatchResult.Match.captures]. `helpText` is optional
+ * human-facing documentation for grammar rendering and help output.
  */
-data class CommandArgSpec<T>(val name: String, val type: CommandArgType<T>)
+data class CommandArgSpec<T>(
+    val name: String,
+    val type: CommandArgType<T>,
+    val helpText: String? = null,
+) {
+    fun renderGrammar(): String = "<$name:${type.syntaxName}>"
+}

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandArgType.kt
@@ -5,7 +5,12 @@ package dev.streampack.core.parser
  * Strategy interface for validating and converting a token into a typed argument.
  *
  * Returning null signals that the token is invalid for this argument specification.
+ *
+ * [syntaxName] is the parser's human-readable name for this argument type. It is used when
+ * rendering grammar/help output from [CommandPatternMatcher].
  */
 sealed interface CommandArgType<T> {
+    val syntaxName: String
+
     fun parse(token: String): T?
 }

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandPattern.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandPattern.kt
@@ -13,4 +13,7 @@ data class CommandPattern(
     val literals: List<String>,
     val args: List<CommandArgSpec<*>> = emptyList(),
     val caseInsensitiveLiterals: Boolean = true,
-)
+    val summary: String? = null,
+) {
+    fun renderGrammar(): String = (literals + args.map { it.renderGrammar() }).joinToString(" ")
+}

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandPatternMatcher.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/CommandPatternMatcher.kt
@@ -10,6 +10,9 @@ package dev.streampack.core.parser
  * - otherwise return the strongest failure signal among literal matches
  *   ([CommandMatchResult.InvalidArgument] > [CommandMatchResult.MissingArguments] > [CommandMatchResult.TooManyArguments])
  * - return null if no literal prefix matched
+ *
+ * The matcher can also render its own grammar/help lines via [describeGrammar] and [describeHelp].
+ * This keeps parser-driven command documentation close to the command definitions themselves.
  */
 class CommandPatternMatcher(private val patterns: List<CommandPattern>) {
     fun match(raw: String): CommandMatchResult? {
@@ -83,6 +86,33 @@ class CommandPatternMatcher(private val patterns: List<CommandPattern>) {
         }
 
         return if (matchedLiteralPrefix) fallback else null
+    }
+
+    /**
+     * Renders one BNF-ish grammar line per configured pattern.
+     *
+     * Example output:
+     *
+     * `boolean xor <left:one-of(false|true)> <right:one-of(false|true)>`
+     */
+    fun describeGrammar(): List<String> = patterns.map { it.renderGrammar() }
+
+    /**
+     * Renders grammar plus any available summaries and argument help text.
+     *
+     * The output format is intentionally plain list-of-strings so callers can publish it directly
+     * in chat, logs, or docs without depending on a richer presentation model.
+     */
+    fun describeHelp(): List<String> {
+        val lines = mutableListOf<String>()
+        for (pattern in patterns) {
+            val summarySuffix = pattern.summary?.let { " -- $it" } ?: ""
+            lines += pattern.renderGrammar() + summarySuffix
+            for (arg in pattern.args) {
+                arg.helpText?.let { lines += "  ${arg.renderGrammar()}: $it" }
+            }
+        }
+        return lines
     }
 
     private fun matchesLiterals(pattern: CommandPattern, tokens: List<String>): Boolean {

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/HttpUrlArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/HttpUrlArgType.kt
@@ -5,6 +5,8 @@ import java.net.URI
 
 /** URL validator that accepts only absolute http/https URLs with a host. */
 data object HttpUrlArgType : CommandArgType<String> {
+    override val syntaxName: String = "http-url"
+
     override fun parse(token: String): String? {
         val uri =
             try {

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/IntRangeArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/IntRangeArgType.kt
@@ -3,5 +3,7 @@ package dev.streampack.core.parser
 
 /** Parses an integer constrained to the inclusive [range]. */
 data class IntRangeArgType(private val range: IntRange) : CommandArgType<Int> {
+    override val syntaxName: String = "int[${range.first}..${range.last}]"
+
     override fun parse(token: String): Int? = token.toIntOrNull()?.takeIf { it in range }
 }

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/PositiveIntArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/PositiveIntArgType.kt
@@ -3,6 +3,8 @@ package dev.streampack.core.parser
 
 /** Parses strictly positive base-10 integers (`1..Int.MAX_VALUE`). */
 data object PositiveIntArgType : CommandArgType<Int> {
+    override val syntaxName: String = "positive-int"
+
     override fun parse(token: String): Int? {
         val value = token.toIntOrNull() ?: return null
         return value.takeIf { it > 0 }

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/StringArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/StringArgType.kt
@@ -3,5 +3,7 @@ package dev.streampack.core.parser
 
 /** Pass-through argument type that accepts any single token. */
 data object StringArgType : CommandArgType<String> {
+    override val syntaxName: String = "string"
+
     override fun parse(token: String): String = token
 }

--- a/lib-core/src/main/kotlin/dev/streampack/core/parser/UsernameArgType.kt
+++ b/lib-core/src/main/kotlin/dev/streampack/core/parser/UsernameArgType.kt
@@ -3,6 +3,8 @@ package dev.streampack.core.parser
 
 /** Username validator for common cross-protocol account naming constraints. */
 data object UsernameArgType : CommandArgType<String> {
+    override val syntaxName: String = "username"
+
     private val usernamePattern = Regex("^[A-Za-z0-9_-]{2,64}$")
 
     override fun parse(token: String): String? = token.takeIf { usernamePattern.matches(it) }

--- a/lib-core/src/test/kotlin/dev/streampack/core/parser/CommandParserTests.kt
+++ b/lib-core/src/test/kotlin/dev/streampack/core/parser/CommandParserTests.kt
@@ -8,6 +8,57 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class CommandParserTests {
+    private val booleanArgType = ChoiceArgType(setOf("true", "false"))
+
+    private fun booleanArg(name: String, helpText: String? = null): CommandArgSpec<String> =
+        CommandArgSpec(name, booleanArgType, helpText)
+
+    private fun booleanMatcher(): CommandPatternMatcher =
+        CommandPatternMatcher(
+            listOf(
+                CommandPattern(
+                    name = "boolean_xor",
+                    literals = listOf("boolean", "xor"),
+                    args =
+                        listOf(
+                            booleanArg("left", "Left boolean operand"),
+                            booleanArg("right", "Right boolean operand"),
+                        ),
+                    summary = "Exclusive-or over two boolean inputs",
+                ),
+                CommandPattern(
+                    name = "boolean_and",
+                    literals = listOf("boolean", "and"),
+                    args =
+                        listOf(
+                            booleanArg("left", "Left boolean operand"),
+                            booleanArg("right", "Right boolean operand"),
+                        ),
+                    summary = "Logical and over two boolean inputs",
+                ),
+                CommandPattern(
+                    name = "boolean_or",
+                    literals = listOf("boolean", "or"),
+                    args =
+                        listOf(
+                            booleanArg("left", "Left boolean operand"),
+                            booleanArg("right", "Right boolean operand"),
+                        ),
+                    summary = "Logical or over two boolean inputs",
+                ),
+                CommandPattern(
+                    name = "boolean_not",
+                    literals = listOf("boolean", "not"),
+                    args = listOf(booleanArg("value", "Boolean input to negate")),
+                    summary = "Logical not over one boolean input",
+                ),
+                CommandPattern(
+                    name = "boolean_help",
+                    literals = listOf("boolean", "help"),
+                    summary = "Show boolean command help",
+                ),
+            )
+        )
 
     private val matcher =
         CommandPatternMatcher(
@@ -199,5 +250,70 @@ class CommandParserTests {
             CommandMatchResult.InvalidArgument::class.java,
             urlMatcher.match("suggest file:///tmp/test"),
         )
+    }
+
+    @Test
+    fun `matcher can render grammar lines for boolean command tree`() {
+        assertEquals(
+            listOf(
+                "boolean xor <left:one-of(false|true)> <right:one-of(false|true)>",
+                "boolean and <left:one-of(false|true)> <right:one-of(false|true)>",
+                "boolean or <left:one-of(false|true)> <right:one-of(false|true)>",
+                "boolean not <value:one-of(false|true)>",
+                "boolean help",
+            ),
+            booleanMatcher().describeGrammar(),
+        )
+    }
+
+    @Test
+    fun `matcher can render help lines with summaries and argument help`() {
+        assertEquals(
+            listOf(
+                "boolean xor <left:one-of(false|true)> <right:one-of(false|true)> -- Exclusive-or over two boolean inputs",
+                "  <left:one-of(false|true)>: Left boolean operand",
+                "  <right:one-of(false|true)>: Right boolean operand",
+                "boolean and <left:one-of(false|true)> <right:one-of(false|true)> -- Logical and over two boolean inputs",
+                "  <left:one-of(false|true)>: Left boolean operand",
+                "  <right:one-of(false|true)>: Right boolean operand",
+                "boolean or <left:one-of(false|true)> <right:one-of(false|true)> -- Logical or over two boolean inputs",
+                "  <left:one-of(false|true)>: Left boolean operand",
+                "  <right:one-of(false|true)>: Right boolean operand",
+                "boolean not <value:one-of(false|true)> -- Logical not over one boolean input",
+                "  <value:one-of(false|true)>: Boolean input to negate",
+                "boolean help -- Show boolean command help",
+            ),
+            booleanMatcher().describeHelp(),
+        )
+    }
+
+    @Test
+    fun `boolean binary commands match typed boolean choice arguments`() {
+        val cases =
+            mapOf(
+                "boolean xor true false" to "boolean_xor",
+                "boolean and true false" to "boolean_and",
+                "boolean or true false" to "boolean_or",
+            )
+
+        for ((input, patternName) in cases) {
+            val result = booleanMatcher().match(input)
+
+            assertInstanceOf(CommandMatchResult.Match::class.java, result)
+            result as CommandMatchResult.Match
+            assertEquals(patternName, result.patternName)
+            assertEquals("true", result.captures["left"])
+            assertEquals("false", result.captures["right"])
+        }
+    }
+
+    @Test
+    fun `boolean not command matches one typed boolean choice argument`() {
+        val result = booleanMatcher().match("boolean not false")
+
+        assertInstanceOf(CommandMatchResult.Match::class.java, result)
+        result as CommandMatchResult.Match
+        assertEquals("boolean_not", result.patternName)
+        assertEquals("false", result.captures["value"])
     }
 }

--- a/lib-factoid/pom.xml
+++ b/lib-factoid/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-factoid</artifactId>

--- a/lib-generative/pom.xml
+++ b/lib-generative/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-generative</artifactId>

--- a/lib-irc/pom.xml
+++ b/lib-irc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-irc</artifactId>

--- a/lib-polling/pom.xml
+++ b/lib-polling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-polling</artifactId>

--- a/lib-slack/pom.xml
+++ b/lib-slack/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-slack</artifactId>

--- a/lib-startrader/pom.xml
+++ b/lib-startrader/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-startrader</artifactId>

--- a/lib-taxonomy/pom.xml
+++ b/lib-taxonomy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-taxonomy</artifactId>

--- a/lib-testsupport/pom.xml
+++ b/lib-testsupport/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-testsupport</artifactId>

--- a/lib-web/pom.xml
+++ b/lib-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>lib-web</artifactId>

--- a/operation-21/pom.xml
+++ b/operation-21/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-21</artifactId>

--- a/operation-ask/pom.xml
+++ b/operation-ask/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-ask</artifactId>

--- a/operation-cal/pom.xml
+++ b/operation-cal/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-cal</artifactId>

--- a/operation-calc/pom.xml
+++ b/operation-calc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-calc</artifactId>

--- a/operation-dictionary/pom.xml
+++ b/operation-dictionary/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-dictionary</artifactId>

--- a/operation-factoid/pom.xml
+++ b/operation-factoid/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-factoid</artifactId>

--- a/operation-hangman/pom.xml
+++ b/operation-hangman/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-hangman</artifactId>

--- a/operation-ideas/pom.xml
+++ b/operation-ideas/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-ideas</artifactId>

--- a/operation-karma/pom.xml
+++ b/operation-karma/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-karma</artifactId>

--- a/operation-markov/pom.xml
+++ b/operation-markov/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-markov</artifactId>

--- a/operation-poetry/pom.xml
+++ b/operation-poetry/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-poetry</artifactId>

--- a/operation-safecracker/pom.xml
+++ b/operation-safecracker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-safecracker</artifactId>

--- a/operation-sentiment/pom.xml
+++ b/operation-sentiment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-sentiment</artifactId>

--- a/operation-specs/pom.xml
+++ b/operation-specs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-specs</artifactId>

--- a/operation-tell/pom.xml
+++ b/operation-tell/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-tell</artifactId>

--- a/operation-urltitle/pom.xml
+++ b/operation-urltitle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-urltitle</artifactId>

--- a/operation-weather/pom.xml
+++ b/operation-weather/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>operation-weather</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <groupId>dev.streampack</groupId>
     <artifactId>streampack-parent</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/server-streampack/pom.xml
+++ b/server-streampack/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>server-streampack</artifactId>

--- a/service-blog/pom.xml
+++ b/service-blog/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-blog</artifactId>

--- a/service-blog/src/main/kotlin/dev/streampack/blog/controller/PostController.kt
+++ b/service-blog/src/main/kotlin/dev/streampack/blog/controller/PostController.kt
@@ -14,6 +14,7 @@ import dev.streampack.blog.model.EditContentHttpRequest
 import dev.streampack.blog.model.EditContentRequest
 import dev.streampack.blog.model.FindContentRequest
 import dev.streampack.blog.model.PostStatus
+import dev.streampack.blog.model.RecordPostAccessRequest
 import dev.streampack.blog.model.SuggestTagsHttpRequest
 import dev.streampack.blog.model.SuggestTagsRequest
 import dev.streampack.blog.model.SuggestTagsResponse
@@ -131,7 +132,9 @@ class PostController(
     ): ResponseEntity<*> {
         val user = resolveUser(httpRequest)
         val payload = FindContentRequest.FindBySlug("$year/${"%02d".format(month)}/$slug")
-        return dispatch(payload, "posts/detail", user) { result -> mapError(result) }
+        return maybeTrackPostAccess(
+            dispatch(payload, "posts/detail", user) { result -> mapError(result) }
+        )
     }
 
     @Operation(
@@ -158,7 +161,19 @@ class PostController(
     ): ResponseEntity<*> {
         val user = resolveUser(httpRequest)
         val payload = FindContentRequest.FindById(id)
-        return dispatch(payload, "posts/detail", user) { result -> mapError(result) }
+        return maybeTrackPostAccess(
+            dispatch(payload, "posts/detail", user) { result -> mapError(result) }
+        )
+    }
+
+    @Operation(summary = "Record a UI-driven access of a blog post")
+    @ApiResponse(responseCode = "202", description = "Access tracking accepted")
+    @PostMapping("/posts/{id}/access")
+    fun recordPostAccess(
+        @Parameter(description = "Post UUIDv7") @PathVariable id: UUID
+    ): ResponseEntity<Void> {
+        eventGateway.send(MessageBuilder.withPayload(RecordPostAccessRequest(id)).build())
+        return ResponseEntity.accepted().build()
     }
 
     @Operation(
@@ -472,6 +487,16 @@ class PostController(
                     )
             }
         }
+    }
+
+    private fun maybeTrackPostAccess(response: ResponseEntity<*>): ResponseEntity<*> {
+        val detail = response.body as? ContentDetail ?: return response
+        if (response.statusCode.is2xxSuccessful) {
+            eventGateway.send(
+                MessageBuilder.withPayload(RecordPostAccessRequest(detail.id)).build()
+            )
+        }
+        return response
     }
 
     /** Maps an error to the appropriate HTTP status based on error message content */

--- a/service-blog/src/main/kotlin/dev/streampack/blog/controller/SsrController.kt
+++ b/service-blog/src/main/kotlin/dev/streampack/blog/controller/SsrController.kt
@@ -5,6 +5,7 @@ import dev.streampack.blog.config.BlogProperties
 import dev.streampack.blog.model.ContentDetail
 import dev.streampack.blog.model.ContentListResponse
 import dev.streampack.blog.model.FindContentRequest
+import dev.streampack.blog.model.RecordPostAccessRequest
 import dev.streampack.core.integration.EventGateway
 import dev.streampack.core.model.OperationResult
 import dev.streampack.core.model.Protocol
@@ -77,6 +78,7 @@ class SsrController(
         }
 
         val detail = result.payload as ContentDetail
+        eventGateway.send(MessageBuilder.withPayload(RecordPostAccessRequest(detail.id)).build())
         val canonicalUrl = "$baseUrl/posts/${esc(detail.slug)}"
         val tags = detail.tags.joinToString(", ")
 

--- a/service-blog/src/test/kotlin/dev/streampack/blog/controller/PostControllerTests.kt
+++ b/service-blog/src/test/kotlin/dev/streampack/blog/controller/PostControllerTests.kt
@@ -22,6 +22,7 @@ import dev.streampack.test.ResetDatabaseBeforeEach
 import dev.streampack.test.TestChannelConfiguration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -131,6 +132,7 @@ class PostControllerTests {
             jsonPath("$.title") { value("Published Post") }
             jsonPath("$.renderedHtml") { isNotEmpty() }
         }
+        waitForAccessCount(publishedPost.id, 1)
     }
 
     @Test
@@ -139,6 +141,21 @@ class PostControllerTests {
             status { isNotFound() }
             jsonPath("$.detail") { value("Post not found") }
         }
+    }
+
+    @Test
+    fun `POST post access returns accepted`() {
+        mockMvc.post("/posts/${publishedPost.id}/access").andExpect { status { isAccepted() } }
+    }
+
+    @Test
+    fun `GET post by id returns detail and increments access count`() {
+        mockMvc.get("/posts/${publishedPost.id}").andExpect {
+            status { isOk() }
+            jsonPath("$.id") { value(publishedPost.id.toString()) }
+            jsonPath("$.title") { value("Published Post") }
+        }
+        waitForAccessCount(publishedPost.id, 1)
     }
 
     // --- GET /posts/search ---
@@ -217,6 +234,15 @@ class PostControllerTests {
                 status { isBadRequest() }
                 jsonPath("$.detail") { value("Title is required") }
             }
+    }
+
+    private fun waitForAccessCount(postId: java.util.UUID, expected: Long) {
+        repeat(40) {
+            val current = postRepository.findById(postId).orElseThrow().accessCount
+            if (current == expected) return
+            Thread.sleep(25)
+        }
+        assertEquals(expected, postRepository.findById(postId).orElseThrow().accessCount)
     }
 
     @Test

--- a/service-blog/src/test/kotlin/dev/streampack/blog/controller/SsrControllerTests.kt
+++ b/service-blog/src/test/kotlin/dev/streampack/blog/controller/SsrControllerTests.kt
@@ -18,6 +18,7 @@ import dev.streampack.test.TestChannelConfiguration
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -128,6 +129,7 @@ class SsrControllerTests {
                 content { string(org.hamcrest.Matchers.containsString("A post for SSR testing")) }
                 content { string(org.hamcrest.Matchers.containsString("canonical")) }
             }
+        waitForAccessCount(publishedPost.id, 1)
     }
 
     @Test
@@ -173,5 +175,14 @@ class SsrControllerTests {
                 content { string(org.hamcrest.Matchers.containsString("robots")) }
                 content { string(org.hamcrest.Matchers.containsString("index, follow")) }
             }
+    }
+
+    private fun waitForAccessCount(postId: java.util.UUID, expected: Long) {
+        repeat(40) {
+            val current = postRepository.findById(postId).orElseThrow().accessCount
+            if (current == expected) return
+            Thread.sleep(25)
+        }
+        assertEquals(expected, postRepository.findById(postId).orElseThrow().accessCount)
     }
 }

--- a/service-bridge/pom.xml
+++ b/service-bridge/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-bridge</artifactId>

--- a/service-console/pom.xml
+++ b/service-console/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-console</artifactId>

--- a/service-discord/pom.xml
+++ b/service-discord/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-discord</artifactId>

--- a/service-factoid/pom.xml
+++ b/service-factoid/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-factoid</artifactId>

--- a/service-features/pom.xml
+++ b/service-features/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-features</artifactId>

--- a/service-github/pom.xml
+++ b/service-github/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-github</artifactId>

--- a/service-irc/pom.xml
+++ b/service-irc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-irc</artifactId>

--- a/service-karma/pom.xml
+++ b/service-karma/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-karma</artifactId>

--- a/service-mail/pom.xml
+++ b/service-mail/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-mail</artifactId>

--- a/service-mcp/pom.xml
+++ b/service-mcp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-mcp</artifactId>

--- a/service-rss/pom.xml
+++ b/service-rss/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-rss</artifactId>

--- a/service-rss/src/main/kotlin/dev/streampack/rss/controller/RssAggregatorController.kt
+++ b/service-rss/src/main/kotlin/dev/streampack/rss/controller/RssAggregatorController.kt
@@ -44,21 +44,6 @@ class RssAggregatorController(
         @RequestParam(required = false) title: String?,
     ): RssAggregatedItemsResponse = rssAggregatorService.listItems(page, size, feed, title)
 
-    @Operation(summary = "Generate an aggregated RSS feed of stored items")
-    @ApiResponse(
-        responseCode = "200",
-        description = "Aggregated RSS feed",
-        content = [Content(mediaType = "application/rss+xml")],
-    )
-    @GetMapping("/sources.xml", produces = ["application/rss+xml"])
-    fun aggregatedFeed(
-        @RequestParam(required = false) feed: String?,
-        @RequestParam(required = false) title: String?,
-    ): ResponseEntity<String> =
-        ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType("application/rss+xml; charset=utf-8"))
-            .body(rssAggregatorService.aggregatedFeed(feed, title))
-
     @Operation(summary = "Record a UI-driven access of a stored RSS item")
     @ApiResponse(responseCode = "202", description = "Access tracking accepted")
     @PostMapping("/items/{id}/access")

--- a/service-rss/src/main/kotlin/dev/streampack/rss/service/RssAggregatorService.kt
+++ b/service-rss/src/main/kotlin/dev/streampack/rss/service/RssAggregatorService.kt
@@ -1,10 +1,6 @@
 /* Joseph B. Ottinger (C)2026 */
 package dev.streampack.rss.service
 
-import com.rometools.rome.feed.synd.SyndContentImpl
-import com.rometools.rome.feed.synd.SyndEntryImpl
-import com.rometools.rome.feed.synd.SyndFeedImpl
-import com.rometools.rome.io.SyndFeedOutput
 import dev.streampack.rss.entity.RssEntry
 import dev.streampack.rss.model.RssAggregatedItemResponse
 import dev.streampack.rss.model.RssAggregatedItemsResponse
@@ -43,33 +39,6 @@ class RssAggregatorService(private val entryRepository: RssEntryRepository) {
             totalPages = results.totalPages,
             totalCount = results.totalElements,
         )
-    }
-
-    fun aggregatedFeed(feed: String?, title: String?): String {
-        val items = listItems(0, 100, feed, title).items
-        val syndFeed =
-            SyndFeedImpl().apply {
-                feedType = "rss_2.0"
-                this.title = "Streampack Source Aggregator"
-                link = "https://bytecode.news/rss/sources.xml"
-                description = "Aggregated stored RSS entries across configured Streampack sources"
-                publishedDate = items.firstOrNull()?.publishedAt?.let { java.util.Date.from(it) }
-                entries =
-                    items.map { item ->
-                        SyndEntryImpl().apply {
-                            uri = item.guid
-                            link = item.link
-                            this.setTitle(item.title)
-                            publishedDate = item.publishedAt?.let { java.util.Date.from(it) }
-                            description =
-                                SyndContentImpl().apply {
-                                    type = "text/plain"
-                                    value = "Source: ${item.feedTitle}"
-                                }
-                        }
-                    }
-            }
-        return SyndFeedOutput().outputString(syndFeed)
     }
 
     @Transactional

--- a/service-rss/src/test/kotlin/dev/streampack/rss/controller/RssAggregatorControllerTests.kt
+++ b/service-rss/src/test/kotlin/dev/streampack/rss/controller/RssAggregatorControllerTests.kt
@@ -134,24 +134,6 @@ class RssAggregatorControllerTests {
     }
 
     @Test
-    fun `GET rss sources xml returns filtered aggregated rss`() {
-        mockMvc.get("/rss/sources.xml?title=spring").andExpect {
-            status { isOk() }
-            content { contentTypeCompatibleWith("application/rss+xml") }
-            content { string(org.hamcrest.Matchers.containsString("<rss")) }
-            content { string(org.hamcrest.Matchers.containsString("Spring Release Notes")) }
-            content { string(org.hamcrest.Matchers.containsString("Spring Signals")) }
-            content {
-                string(
-                    org.hamcrest.Matchers.not(
-                        org.hamcrest.Matchers.containsString("Kotlin Roundup")
-                    )
-                )
-            }
-        }
-    }
-
-    @Test
     fun `POST rss item access returns accepted`() {
         mockMvc.post("/rss/items/$bytecodeSpringId/access").andExpect { status { isAccepted() } }
     }

--- a/service-slack/pom.xml
+++ b/service-slack/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.streampack</groupId>
         <artifactId>streampack-parent</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.8</version>
     </parent>
 
     <artifactId>service-slack</artifactId>


### PR DESCRIPTION
Fixes #25 - remove extraneous sources.xml, which was sort of duplicated by other endpoints
Fixes #23 - adds a global feed endpoint, all RSS feeds consumed by the bot
Fixes #18 - updates the command parser and adds documentation and examples
